### PR TITLE
Nest routers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 node_js:
 - "0.10"
 - "0.11"
+sudo: false
 language: node_js
-install: "npm install"
-script:
-  - ./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --report lcovonly --recursive -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+script: "npm run test-cov"
+after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ router.on('/404', () => console.log('/404'))
 router.on('/:user', () => console.log('/user'))
 
 router.match('/tobi')
-// => '/:user'
+// => '/user'
 ```
 
 ## API
@@ -46,7 +46,20 @@ Partial paths are supported through the `/:` operator, and the callback
 provides a param object. With a route like `/:user` if you navigated to
 `/somename`, you'd get a param object like this: `{ user: 'somename' }`.
 ```js
-router.on('/:user', (uri, param) => console.log('do user stuff', param.user))
+router.on('/:user', (uri, param) => console.log('my name is ', param.user))
+```
+
+Nested routers are supported by passing in `.match()` as the callback to
+another router.
+```js
+const main = wayfarer()
+const sub  = wayfarer()
+
+main.on('/foo', sub.match.bind(sub))
+sub.on('/foo/bar'), (uri) => console.log(uri))
+
+main.match('/foo/bar')
+// '/foo/bar'
 ```
 
 #### .match(path)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_ENV=test tape test.js | tap-bail | tap-spec",
-    "test-cov": "NODE_ENV=test istanbul test.js | tap-bail "
+    "test-cov": "NODE_ENV=test istanbul cover test.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -64,6 +64,15 @@ test('.match() should not match queryStrings', function(t) {
   router.match('/404?derp=darp')
 })
 
+test('.match() should provide the uri string to callback', function(t) {
+  t.plan(1)
+  const router = wayfarer()
+  const sub = wayfarer()
+  router.on('/home', sub.match.bind(sub))
+  sub.on('/home', function(uri) { t.equal(uri, '/home') })
+  router.match('/home')
+})
+
 test('aliases', function(t) {
   t.plan(2)
   const router = wayfarer()


### PR DESCRIPTION
Adds nested routers, dependant on https://github.com/yoshuawuyts/wayfarer/pull/5

Syntax is a bit ugly imo, but should do for now. If anyone has a better idea on how to do nesting without `.match.bind()` I'm all ears.
