### PR TITLE
subrouting: init

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![js-standard-style][standard-image]][standard-url]
 
 Composable [trie based](https://github.com/jonathanong/routington/) router.
+It is faster than traditional, linear, regular expression-matching routers,
+although insignficantly, and scales with the number of routes.
 
 ## Installation
 ```bash
@@ -32,15 +34,13 @@ router('/uh/oh')
 ## Subrouting
 Routers can be infinitely nested, allowing routing to be scoped per view.
 ```js
-const wayfarer = require('wayfarer')
-
 const r1 = wayfarer()
 const r2 = wayfarer()
 
-r1.on('/', r2)
-r2.on('/', () => console.log('subrouter trix!'))
+r1.on('/:parent', r2)
+r2.on('/child', () => console.log('subrouter trix!'))
 
-r1('/')
+r1('/dada/child')
 // => 'subrouter trix!'
 ```
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "routington": "^1.0.2"
+    "es6-symbol": "^2.0.1",
+    "routington": "^1.0.2",
+    "xtend": "^4.0.0"
   },
   "devDependencies": {
     "istanbul": "^0.2.11",

--- a/test.js
+++ b/test.js
@@ -36,15 +36,43 @@ test('.emit() should match partials', function (t) {
   r('/tobi')
 })
 
-test('.emit() should allow nesting', function (t) {
+test('.emit() should throw if no matches are found', function (t) {
   t.plan(1)
+  const r1 = wayfarer()
+  t.throws(r1.bind(r1, '/woops'), /path/)
+})
+
+test('.emit() should allow nesting', function (t) {
+  t.plan(5)
+
   const r1 = wayfarer()
   const r2 = wayfarer()
   r1.on('/home', r2)
-  r2.on('/home', function (uri) {
-    t.equal(uri, '/home')
+  r2.on('/', function (uri) {
+    t.equal(uri, '/')
   })
+
   r1('/home')
+
+  const r3 = wayfarer()
+  const r4 = wayfarer()
+  r3.on('/parent', r4)
+  r4.on('/child', function (uri) {
+    t.equal(uri, '/child')
+  })
+
+  r3('/parent/child')
+
+  const r5 = wayfarer()
+  const r6 = wayfarer()
+  r5.on('/:parent', r6)
+  r6.on('/child', function (uri, param) {
+    t.equal(typeof param, 'object')
+    t.equal(param.parent, 'hello')
+    t.equal(uri, '/child')
+  })
+
+  r5('/hello/child')
 })
 
 test('aliases', function (t) {
@@ -56,11 +84,14 @@ test('aliases', function (t) {
 test('.match()', function (t) {
   t.plan(3)
   const r = wayfarer()
+
   r.on('/user/:id', function (uri) {
     t.equal(uri, '/user/once', 'route not called with .match()')
   })
+
+  r('/user/once')
+
   const matched = r.match('/user/matched')
   t.equal(matched.param.id, 'matched')
   t.equal(typeof matched.node.cb, 'function')
-  r('/user/once')
 })


### PR DESCRIPTION
Closes #12. Super excited about landing this as it allows for modular, decoupled views. Think it might affect the way I build projects by a lot (separate views in separate projects, joining them when done / deployed).

Changes
------------
- __browser__: moved back to `const` as it's safer and works in `node>=0.10`. If `IE<=9` support is needed it's recommended to use a precompiler such as `babel`.
- __nesting__: routes are now more easily nested. Parent  / children routers no longer need to be aware of each other's context, allowing views to be decoupled.