### PR TITLE
Add .match() for just matching and returning routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ for all route options.
 ### router(route)
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
 
+### router.match(route)
+Match and return a route without executing the corresponding callback.
+
 ## Why?
 Routers like [react-router](https://github.com/rackt/react-router) are
 complicated solutions for a simple problem. All I want is a

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
-const routington = require('routington')
-const assert = require('assert')
+var routington = require('routington')
+var assert = require('assert')
 
 module.exports = wayfarer
 
@@ -7,10 +7,11 @@ module.exports = wayfarer
 // str -> obj
 function wayfarer (dft) {
   dft = dft || ''
-  const router = routington()
+  var router = routington()
 
   emit.emit = emit
   emit.on = on
+  emit.match = match
 
   return emit
 
@@ -19,16 +20,22 @@ function wayfarer (dft) {
   function on (path, cb) {
     assert.equal(typeof path, 'string')
     assert.equal(typeof cb, 'function')
-    const node = router.define(path)[0]
+    var node = router.define(path)[0]
     node.cb = cb
     return emit
   }
 
-  // match a route
+  // match and call a route
   // str -> null
   function emit (path) {
     path = path || ''
-    const match = router.match(path) || router.match(dft)
-    match.node.cb(path, match ? match.param : {})
+    var matched = match(path)
+    if (matched) matched.node.cb(path, matched.param)
+  }
+
+  // match and return route
+  // str -> obj
+  function match (path) {
+    return router.match(path) || router.match(dft)
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "istanbul": "^0.2.11",
     "mocha": "^1.20.1",
+    "standard": "^4.0.1",
     "tape": "^3.0.3"
   },
   "files": [

--- a/test.js
+++ b/test.js
@@ -52,3 +52,14 @@ test('aliases', function (t) {
   const r = wayfarer()
   t.equal(r, r.emit)
 })
+
+test('.match()', function (t) {
+  t.plan(2)
+  const r = wayfarer()
+  r.on('/user/:id', function () {
+    t.fail('route should not be called with .match()')
+  })
+  const matched = r.match('/user/123')
+  t.equal(matched.param.id, '123')
+  t.equal(typeof matched.node.cb, 'function')
+})


### PR DESCRIPTION
Here are the basic changes needed to have `base-router` run using `wayfarer`.

This allows me to do:

```js
var router = wayfarer()

// Check if the route exists without calling the callback
var matched = router.match(name)
if (!matched) done(new Error('404'))

// Call the callback with custom params and inspect the return
try {
  var data = matched.node.cb(params, done)
  // is data a promise or just return value?
} catch (err) {
  done(err)
}
```

Also it changes the `const` to `var` which makes it compatible with IE and node.js.

I figured this was an easier way to show the changes needed. Thanks for the consideration!