### PR TITLE
match: remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ for all route options.
 ### router(route)
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
 
-### router.match(route)
-Match and return a route without executing the corresponding callback.
-
 ## Why?
 Routers like [react-router](https://github.com/rackt/react-router) are
 complicated solutions for a simple problem. All I want is a

--- a/index.js
+++ b/index.js
@@ -14,7 +14,6 @@ function wayfarer (dft) {
   const router = routington()
   const mounts = routington()
 
-  emit.match = match
   emit[sym] = true
   emit.emit = emit
   emit.on = on
@@ -48,10 +47,10 @@ function wayfarer (dft) {
       path = nw.join('/')
     }
 
-    const matched = mountPath ? mountPath : match(path)
-    assert.ok(matched, 'path ' + path + ' did not match')
-    param = xtend(param, matched.param)
-    matched.node.cb('/' + path, param)
+    const mch = mountPath ? mountPath : router.match(path) || router.match(dft)
+    assert.ok(mch, 'path ' + path + ' did not match')
+    param = xtend(param, mch.param)
+    mch.node.cb('/' + path, param)
   }
 
   // mount a subrouter
@@ -61,13 +60,6 @@ function wayfarer (dft) {
     const node = mounts.define(path)[0]
     node.cb = cb
     return emit
-  }
-
-  // match and return route
-  // str -> obj
-  function match (path) {
-    path = sanitizeUri(path) || ''
-    return router.match(path) || router.match(dft)
   }
 
   // match a mounted router

--- a/test.js
+++ b/test.js
@@ -80,18 +80,3 @@ test('aliases', function (t) {
   const r = wayfarer()
   t.equal(r, r.emit)
 })
-
-test('.match()', function (t) {
-  t.plan(3)
-  const r = wayfarer()
-
-  r.on('/user/:id', function (uri) {
-    t.equal(uri, '/user/once', 'route not called with .match()')
-  })
-
-  r('/user/once')
-
-  const matched = r.match('/user/matched')
-  t.equal(matched.param.id, 'matched')
-  t.equal(typeof matched.node.cb, 'function')
-})


### PR DESCRIPTION
Closes #17 

## Changes
- __match__: remove, consumers can use `routington` directly instead.