### PR TITLE
on(): enable multiple handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Initialize a router with a default route. Doesn't ignore querystrings and hashes
 
 ### router.on(route, cb(params))
 Register a new route. The order in which routes are registered does not matter.
-See [`routington.define()`](https://github.com/pillarjs/routington#nodes-node--routerdefineroute)
+Multiple callbacks can be registered. See
+[`routington.define()`](https://github.com/pillarjs/routington#nodes-node--routerdefineroute)
 for all route options.
 
 ### router(route)

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ function wayfarer (dft) {
     assert.equal(typeof cb, 'function')
     path = sanitizeUri(path) || ''
     const node = cb[sym] ? mounts.define(path)[0] : router.define(path)[0]
-    node.cb = cb
+    if (Array.isArray(node.cb)) node.cb.push(cb)
+    else node.cb = [cb]
     return emit
   }
 
@@ -45,7 +46,9 @@ function wayfarer (dft) {
     params = xtend(params, match.param)
 
     // only nested routers need a path
-    sub ? match.node.cb(path, params) : match.node.cb(params)
+    match.node.cb.forEach(function (cb) {
+      sub ? cb(path, params) : cb(params)
+    })
   }
 
   // match a mounted router

--- a/test.js
+++ b/test.js
@@ -41,6 +41,20 @@ test('.emit() should throw if no matches are found', function (t) {
   t.throws(r1.bind(r1, '/woops'), /path/)
 })
 
+test('.emi() should allow multiple handlers', function (t) {
+  t.plan(2)
+
+  const r1 = wayfarer()
+  r1.on('/', function () {
+    t.pass('call 1')
+  })
+  r1.on('/', function () {
+    t.pass('call 2')
+  })
+
+  r1('/')
+})
+
 test('.emit() should allow nesting', function (t) {
   t.plan(7)
 


### PR DESCRIPTION
Closes #13. :tada:

## Changes
- __.on()__: enable multiple handlers per route. No longer blindly overrides the previous route.