### PR TITLE
examples: add `hash` and `nested`

### DIFF
--- a/examples/hash.js
+++ b/examples/hash.js
@@ -1,0 +1,20 @@
+const wayfarer = require('wayfarer')
+const match = require('hash-match')
+
+// register router
+const router = wayfarer('/')
+router.on('/', () => console.log('/'))
+router.on('/skills', () => console.log('skills'))
+router.on('/about', () => console.log('about'))
+router.on('/contact', () => console.log('contact'))
+
+// match once on init
+router(match(window.location.hash))
+
+// listen to hash changes
+window.addEventListener('hashchange', () => {
+  router(match(window.location.hash))
+})
+
+// change hash
+window.location.hash = 'contact'

--- a/examples/nested.js
+++ b/examples/nested.js
@@ -1,0 +1,21 @@
+const wayfarer = require('wayfarer')
+
+const userRouter = wayfarer()
+const repoRouter = wayfarer()
+
+userRouter.on('/user/:user', repoRouter)
+repoRouter.on('/:repo', params => {
+  console.log(params.user, params.repo)
+})
+
+userRouter('/user/timoxley/linklocal')
+// => timoxley linklocal
+
+const commitRouter = wayfarer()
+commitRouter.on('/commit/:hash', params => {
+  console.log(params.user, params.repo, params.hash)
+})
+
+repoRouter.on('/:repo', commitRouter)
+userRouter('/user/timoxley/linklocal/commit/cda1eaa8')
+// => timoxley linklocal cda1eaa8


### PR DESCRIPTION
Closes #24. Nested example was adapted from @timoxley's example https://github.com/yoshuawuyts/wayfarer/issues/21#issue-88187680

## Changes
- __examples__: initialize `hash` and `nested`