### PR TITLE
wayfarer: add .default()

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Routes can register multiple callbacks. See
 [`routington.define()`](https://github.com/pillarjs/routington#nodes-node--routerdefineroute)
 for all route options.
 
+### router.default(params)
+Trigger the default route. Useful to trigger errors externally.
+
 ### router(route)
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function wayfarer (dft) {
   const mounts = routington()
 
   emit[sym] = true
+  emit.default = defaultFn
   emit.emit = emit
   emit.on = on
 
@@ -49,6 +50,12 @@ function wayfarer (dft) {
     match.node.cb.forEach(function (cb) {
       sub ? cb(path, params) : cb(params)
     })
+  }
+
+  // match the default route
+  // obj? -> null
+  function defaultFn (params) {
+    emit(dft, params)
   }
 
   // match a mounted router

--- a/test.js
+++ b/test.js
@@ -41,7 +41,7 @@ test('.emit() should throw if no matches are found', function (t) {
   t.throws(r1.bind(r1, '/woops'), /path/)
 })
 
-test('.emi() should allow multiple handlers', function (t) {
+test('.emit() should allow multiple handlers', function (t) {
   t.plan(2)
 
   const r1 = wayfarer()
@@ -98,6 +98,18 @@ test('.emit() should allow nesting', function (t) {
   })
 
   r7('/foo/bin/bar/baz')
+})
+
+test('.default() should trigger the default route', function (t) {
+  t.plan(5)
+  const r = wayfarer('/404')
+  r.on('/404', function (param) {
+    t.pass('called')
+    t.equal(typeof param, 'object')
+    if (param.foo) t.equal(param.foo, 'bar')
+  })
+  r.default()
+  r.default({ foo: 'bar' })
 })
 
 test('aliases', function (t) {


### PR DESCRIPTION
Wish this wasn't needed, but enforcing the use of a wrapper would probably make things more complicated. Closes #26.

## Changes
- __.default()__: default path can now be triggered from the api.