### PR TITLE
default: propagate unmatched routes to parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ router('/uh/oh')
 
 ## Subrouting
 Routers can be infinitely nested, allowing routing to be scoped per view.
-Matched params are passed into subrouters.
+Matched params are passed into subrouters. Nested routes will call their
+parent's default handler if no path matches.
 ```js
 const r1 = wayfarer()
 const r2 = wayfarer()

--- a/examples/nested.js
+++ b/examples/nested.js
@@ -1,8 +1,9 @@
 const wayfarer = require('wayfarer')
 
-const userRouter = wayfarer()
+const userRouter = wayfarer('err')
 const repoRouter = wayfarer()
 
+userRouter.on('/err', () => console.error('path not found'))
 userRouter.on('/user/:user', repoRouter)
 repoRouter.on('/:repo', params => {
   console.log(params.user, params.repo)

--- a/examples/server.js
+++ b/examples/server.js
@@ -4,10 +4,14 @@ const http = require('http')
 
 const server = http.createServer((req, res) => {
   const router = wayfarer()
-  router.on('/hello', methodist(req, {
+  const method = methodist(req, router)
+
+  router.on('/hello', method({
     all: params => console.log('any route matches'),
     get: params => console.log('get')
   }))
+
+  router(req)
 })
 
 server.listen(1337)

--- a/test.js
+++ b/test.js
@@ -112,6 +112,34 @@ test('.default() should trigger the default route', function (t) {
   r.default({ foo: 'bar' })
 })
 
+test('nested routes should call parent default route', function (t) {
+  t.plan(5)
+  var baz = false
+  const r1 = wayfarer('/404')
+  const r2 = wayfarer()
+  const r3 = wayfarer()
+  const r4 = wayfarer()
+
+  r1.on('foo', r2)
+  r1.on('/404', pass)
+  r2.on('/bar', r3)
+  r2.on('/:baz', r4)
+
+  r1('foo')
+  r1('foo/bar')
+
+  baz = true
+  r1('foo/bar/foo')
+
+  function pass (params) {
+    if (baz) {
+      t.equal(typeof params, 'object')
+      t.equal(params.baz, 'foo')
+    }
+    t.pass('called')
+  }
+})
+
 test('aliases', function (t) {
   t.plan(1)
   const r = wayfarer()


### PR DESCRIPTION
Closes GH-28.

## Changes
- __default__: propagate unmatched routes to parent
- __examples__: bump server example to reflect how to use `default` in various scenarios
- __wayfarer__: spread loops over multiple lines to make intent clearer