### PR TITLE
Create wayfarer.go and Router#unbind methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ Routes can register multiple callbacks. See
 [`routington.define()`](https://github.com/pillarjs/routington#nodes-node--routerdefineroute)
 for all route options.
 
+### wayfarer.go(route, [params])
+Trigger `route` on all routes that listen for it
+
 ### router(route)
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
+
+### router.unbind()
+Unbind the router
 
 ## Internals
 __Warning__: these methods are considered internal and should only be used when

--- a/index.js
+++ b/index.js
@@ -1,11 +1,14 @@
 const routington = require('routington')
 const symbol = require('es6-symbol')
+const indexof = require('indexof')
 const assert = require('assert')
 const xtend = require('xtend')
 
 const sym = symbol('wayfarer')
 
 module.exports = wayfarer
+
+var routers = []
 
 // create a router
 // str -> obj
@@ -20,8 +23,11 @@ function wayfarer (dft) {
   emit[sym] = true
   emit._sym = sym
 
+  emit.destroy = destroy
   emit.emit = emit
   emit.on = on
+
+  routers.push(emit)
 
   return emit
 
@@ -61,6 +67,12 @@ function wayfarer (dft) {
   // obj? -> null
   function defaultFn (params) {
     emit(dft, params)
+  }
+
+  // tear down the router
+  function destroy () {
+    var i = indexof(routers, this)
+    if (i > -1) routers.splice(i, 1)
   }
 
   // match a mounted router
@@ -104,6 +116,18 @@ function wayfarer (dft) {
     return ret
   }
 }
+
+// dispatch routes without having
+// to create new router instance
+// str -> null
+wayfarer.go = function go (path, params) {
+  routers.forEach(function (router) {
+    router.emit(path, params)
+  })
+}
+
+// expose `routers`
+wayfarer.routers = routers
 
 // strip leading `/`
 // str -> str

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "es6-symbol": "^2.0.1",
+    "indexof": "0.0.1",
     "routington": "^1.0.2",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
Using `wayfarer.go(path, [params])` we can now `require('wayfarer')` across multiple files and dispatch a path from anywhere.  For example, I can declare my react routes in one file and then setup action functions in another file that can call `wayfarer.go('/users')`.

`router.unbind` is mostly to make things easier to test.