### PR TITLE
match: allow additional values to be passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ r1('/dada/child')
 Initialize a router with a default route. Doesn't ignore querystrings and
 hashes.
 
-### router.on(route, cb(params))
+### router.on(route, cb(params, [arg1, ...]))
 Register a new route. The order in which routes are registered does not matter.
 Routes can register multiple callbacks. The callback can return values when
 called.
 
-### val = router(route)
+### val = router(route, [arg1, ...])
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
-Returns a values from the matched route (e.g. useful for streams).
+Returns a values from the matched route (e.g. useful for streams). Any
+additional values will be passed to the matched route.
 
 ## Internals
 Wayfarer is built on an internal trie structure. If you want to build a router

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const assert = require('assert')
+const sliced = require('sliced')
 const trie = require('./trie')
 
 module.exports = Wayfarer
@@ -40,12 +41,19 @@ function Wayfarer (dft) {
   // (str, obj?) -> null
   function emit (route) {
     assert.notEqual(route, undefined, "'route' must be defined")
+    const args = sliced(arguments)
 
     const node = _trie.match(route)
-    if (node && node.cb) return node.cb(node.params)
+    if (node && node.cb) {
+      args[0] = node.params
+      return node.cb.apply(null, args)
+    }
 
     const dft = _trie.match(_default)
-    if (dft && dft.cb) return dft.cb(dft.params)
+    if (dft && dft.cb) {
+      args[0] = dft.params
+      return dft.cb.apply(null, args)
+    }
 
     throw new Error("route '" + route + "' did not match")
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "sliced": "^1.0.1",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -29,6 +29,18 @@ test('should match a default path', function (t) {
   r('/nope')
 })
 
+test('should allow passing of extra values', function (t) {
+  t.plan(2)
+  const foo = {}
+  const bar = {}
+  const r = wayfarer()
+  r.on('/foo', function (params, arg1, arg2) {
+    t.equal(arg1, foo, 'arg1 was passed')
+    t.equal(arg2, bar, 'arg2 was passed')
+  })
+  r('/foo', foo, bar)
+})
+
 test('.on() should catch type errors', function (t) {
   t.plan(2)
   const r = wayfarer()


### PR DESCRIPTION
Allows additional values to be passed in in `.match()`. Makes it easier for routers to be wrapped as additional values now just pass through. Closes #38 