### PR TITLE
Support wildcard params (alternative)

### DIFF
--- a/trie.js
+++ b/trie.js
@@ -24,7 +24,7 @@ Trie.prototype.create = function (route) {
     if (route === undefined) return trie
 
     var node = null
-    if (/^:/.test(route)) {
+    if (/^:|^\*/.test(route)) {
       // if node is a name match, set name and append to ':' node
       if (!trie.nodes['$$']) {
         node = { nodes: {} }
@@ -32,7 +32,10 @@ Trie.prototype.create = function (route) {
       } else {
         node = trie.nodes['$$']
       }
-      trie.name = route.replace(/^:/, '')
+      if (route[0] === '*') {
+        trie.wildcard = true
+      }
+      trie.name = route.substr(1) // remove leading : or *
     } else if (!trie.nodes[route]) {
       node = { nodes: {} }
       trie.nodes[route] = node
@@ -63,6 +66,10 @@ Trie.prototype.match = function (route) {
     if (trie.nodes[route]) {
       // match regular routes first
       return search(index + 1, trie.nodes[route])
+    } else if (trie.wildcard) {
+      // match wildcard routes
+      params[trie.name] = routes.slice(index).join('/')
+      return search(index + 1, trie.nodes['$$'])
     } else if (trie.name) {
       // match named routes
       params[trie.name] = route


### PR DESCRIPTION
@GavinDmello I also need to support wildcard routes in choo, though I wonder if pulling in murl might be more than we need? Here's another approach. I wouldn't call this mergeable yet - there are no tests, it's more of a proof of concept. This supports routes such as `/users/:user/*path` to match a route like `/users/timwis/arbitrary/folder/structure`. At the moment, this doesn't support a named parameter _after_ the wildcard param (ie. `/users/:user/*path/:action`) but that may be possible or perhaps even unnecessary.