### PR TITLE
fix(params): decode params

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -101,6 +101,15 @@ tape('trie', function (t) {
     r('/tobi/baz')
   })
 
+  t.test('.emit() should parse encoded params', function (t) {
+    t.plan(1)
+    const r = wayfarer()
+    r.on('/:channel', function (param) {
+      t.equal(param.channel, '#choo', 'param matched')
+    })
+    r('/%23choo')
+  })
+
   t.test('.emit() should throw if no matches are found', function (t) {
     t.plan(1)
     const r1 = wayfarer()

--- a/trie.js
+++ b/trie.js
@@ -65,7 +65,7 @@ Trie.prototype.match = function (route) {
       return search(index + 1, trie.nodes[route])
     } else if (trie.name) {
       // match named routes
-      params[trie.name] = route
+      params[trie.name] = decodeURIComponent(route)
       return search(index + 1, trie.nodes['$$'])
     } else {
       // no matches found


### PR DESCRIPTION
Tried to do this in https://github.com/yoshuawuyts/sheet-router/issues/70 but I couldn't see a way to  not break if someone walked over the routes and didn't pass the params. So I decoded the params here.