### PR TITLE
Add .match(route) to get a matching route without invoking the handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ Register a new route. The order in which routes are registered does not matter.
 Routes can register multiple callbacks. The callback can return values when
 called.
 
+### matchedRoute = router.match(route)
+Matches a route and returns an object. The returned object contains the properties `{cb, params, route}`. This method does not invoke the callback of a route. If no route matches, the default route will be returned. If no default route matches, an error will be thrown.
+
 ### val = router(route, [arg1, ...])
 Match a route and execute the corresponding callback. Alias: `router.emit()`.
 Returns a values from the matched route (e.g. useful for streams). Any

--- a/test/router.js
+++ b/test/router.js
@@ -2,7 +2,7 @@ var wayfarer = require('../')
 var noop = require('noop2')
 var tape = require('tape')
 
-tape('trie', function (t) {
+tape('router', function (t) {
   t.test('should match a path', function (t) {
     t.plan(1)
     var r = wayfarer()
@@ -62,6 +62,21 @@ tape('trie', function (t) {
     r('/foo/baz')
   })
 
+  t.test('.match() should match paths', function (t) {
+    t.plan(2)
+    var r = wayfarer()
+    r.on('/foo/bar', function () {
+      t.fail('should not call callback')
+    })
+    r.on('/foo/baz', noop)
+
+    var bar = r.match('/foo/bar')
+    t.equal(bar.route, '/foo/bar')
+
+    var baz = r.match('/foo/baz')
+    t.equal(baz.route, '/foo/baz')
+  })
+
   t.test('.emit() should match partials', function (t) {
     t.plan(1)
     var r = wayfarer()
@@ -69,6 +84,14 @@ tape('trie', function (t) {
       t.equal(param.user, 'tobi', 'param matched')
     })
     r('/tobi')
+  })
+
+  t.test('.match() should match partials', function (t) {
+    t.plan(1)
+    var r = wayfarer()
+    r.on('/:user', noop)
+    var toby = r.match('/tobi')
+    t.equal(toby.params.user, 'tobi')
   })
 
   t.test('.emit() should match paths before partials', function (t) {
@@ -84,7 +107,9 @@ tape('trie', function (t) {
   t.test('.emit() should allow path overriding', function (t) {
     t.plan(1)
     var r = wayfarer()
-    r.on('/:user', noop)
+    r.on('/:user', function () {
+      t.fail('wrong callback called')
+    })
     r.on('/:user', function () {
       t.pass('called')
     })
@@ -168,6 +193,16 @@ tape('trie', function (t) {
     // r11.on('/:child', r12)
     // r10.on('/foo/:parent', r11)
     // r10('/foo/bin/bar/baz')
+  })
+
+  t.test('.match() returns a handler of a route', function (t) {
+    t.plan(1)
+    var r = wayfarer()
+    r.on('/:user', function () {
+      t.pass('called')
+    })
+    var toby = r.match('/tobi')
+    toby.cb()
   })
 
   t.test('nested routes should call parent default route', function (t) {
@@ -281,7 +316,7 @@ tape('trie', function (t) {
     r('/test/hel%"Flo')
   })
 
-  t.test('should expose .router property', function (t) {
+  t.test('should expose .route property', function (t) {
     t.plan(1)
     var r = wayfarer()
     r.on('/foo', function () {


### PR DESCRIPTION
Let's begin at the bottom 😁 
(see https://github.com/choojs/choo/pull/613 and https://github.com/choojs/nanorouter/pull/9 for more details)

This PR exposes a new `.match` method on the router which can be used to return a matching route without invoking it directly.

I added that description to the readme:
<hr>

### matchedRoute = router.match(route)
Matches a route and returns an object. The returned object contains the properties `{cb, params, route}`. This method does not invoke the callback of a route. If no route matches, the default route will be returned. If no default route matches, an error will be thrown.

<hr>

Now that `.emit` calls `.match`, I'm not sure how we should handle the tests.
Maybe those two tests are good enough for you.

If the trie module would be private and not documented, I'd also remove the `xtend` when returning the node as we're creating a new object anyways.