### PR TITLE
Fix params support of subrouters

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -181,18 +181,35 @@ tape('router', function (t) {
     r8.on('/bin', r9)
     r7.on('/foo', r8)
     r7('/foo/bin/bar')
+  })
 
-    // var r10 = wayfarer()
-    // var r11 = wayfarer()
-    // var r12 = wayfarer()
-    // r12.on('/:grandchild', function (param) {
-    //   t.equal(param.parent, 'bin', 'nested 3 levels with params')
-    //   t.equal(param.child, 'bar', 'nested 3 levels with params')
-    //   t.equal(param.grandchild, 'baz', 'nested 3 levels with parmas')
-    // })
-    // r11.on('/:child', r12)
-    // r10.on('/foo/:parent', r11)
-    // r10('/foo/bin/bar/baz')
+  t.test('.emit() should match nested partials of subrouters', function (t) {
+    t.plan(3)
+    var r1 = wayfarer()
+    var r2 = wayfarer()
+    var r3 = wayfarer()
+    r3.on('/:grandchild', function (param) {
+      t.equal(param.parent, 'bin', 'nested 3 levels with params')
+      t.equal(param.child, 'bar', 'nested 3 levels with params')
+      t.equal(param.grandchild, 'baz', 'nested 3 levels with parmas')
+    })
+    r2.on('/:child', r3)
+    r1.on('/foo/:parent', r2)
+    r1('/foo/bin/bar/baz')
+  })
+
+  t.test('.match() should return nested partials of subrouters', function (t) {
+    t.plan(3)
+    var r1 = wayfarer()
+    var r2 = wayfarer()
+    var r3 = wayfarer()
+    r3.on('/:grandchild', noop)
+    r2.on('/:child', r3)
+    r1.on('/foo/:parent', r2)
+    var matched = r1.match('/foo/bin/bar/baz')
+    t.equal(matched.params.parent, 'bin')
+    t.equal(matched.params.child, 'bar')
+    t.equal(matched.params.grandchild, 'baz')
   })
 
   t.test('.match() returns a handler of a route', function (t) {

--- a/trie.js
+++ b/trie.js
@@ -115,8 +115,7 @@ Trie.prototype.mount = function (route, trie) {
     key = split[0]
     node = this.create(key)
   } else {
-    var headArr = split.splice(0, split.length - 1)
-    var head = headArr.join('/')
+    var head = split.join('/')
     key = split[0]
     node = this.create(head)
   }


### PR DESCRIPTION
As stated in https://github.com/yoshuawuyts/wayfarer/issues/63, the params of subrouters didn't work at all. This commit fixes that.

Can you think of any case which will break the current functionality?
I didn't have a detailed look at the mount code yet. But I don't get why creating the routes using a different path would fix it without breaking any existing routing logic.