### PR TITLE
Fix callback parameter mutation

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,14 +21,15 @@ function Wayfarer (dft) {
 
   // define a route
   // (str, fn) -> obj
-  function on (route, cb) {
+  function on (route, fn) {
     assert.equal(typeof route, 'string')
-    assert.equal(typeof cb, 'function')
+    assert.equal(typeof fn, 'function')
 
+    var cb = fn._wayfarer && fn._trie ? fn : proxy
     route = route || '/'
     cb.route = route
 
-    if (cb && cb._wayfarer && cb._trie) {
+    if (cb._wayfarer && cb._trie) {
       _trie.mount(route, cb._trie.trie)
     } else {
       var node = _trie.create(route)
@@ -36,6 +37,10 @@ function Wayfarer (dft) {
     }
 
     return emit
+
+    function proxy () {
+      return fn.apply(this, Array.prototype.slice.call(arguments))
+    }
   }
 
   // match and call a route

--- a/test/router.js
+++ b/test/router.js
@@ -341,4 +341,18 @@ tape('router', function (t) {
     })
     r('/foo')
   })
+
+  t.test('should not mutate callback parameter', function (t) {
+    t.plan(4)
+    var r = wayfarer()
+    var routes = ['/foo', '/bar']
+    r.on('/foo', callback)
+    r.on('/bar', callback)
+    r('/foo')
+    r('/bar')
+    function callback () {
+      t.notEqual(this, callback, 'callback was proxied')
+      t.equal(this.route, routes.shift(), 'proxy exposes route property')
+    }
+  })
 })


### PR DESCRIPTION
Reusing the same callback for two routes would overwrite `cb.route` each time resulting in a false match for the first route.

Though arguably an edge case, mutating parameters does make for unexpected behavior.