### PR TITLE
[feat] allow same cbs on different routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,21 @@ var trie = require('./trie')
 
 module.exports = Wayfarer
 
+const clone = function (fn) {
+  var cloneObj = fn
+  if (cloneObj.__isClone) {
+    cloneObj = cloneObj.__clonedFrom
+  }
+
+  var temp = function () { return cloneObj.apply(fn, arguments) }
+  Object.assign(temp, fn)
+
+  temp.__isClone = true
+  temp.__clonedFrom = cloneObj
+
+  return temp
+}
+
 // create a router
 // str -> obj
 function Wayfarer (dft) {
@@ -33,7 +48,7 @@ function Wayfarer (dft) {
       _trie.mount(route, cb._trie.trie)
     } else {
       var node = _trie.create(route)
-      node.cb = cb
+      node.cb = clone(cb)
     }
 
     return emit


### PR DESCRIPTION
There is an issue where 

    app.route('/', view)
    app.route('/b', view) 
    app.route('/c', view)

all end up returning the route as c because wayfarer sticks the route on the reference. which in turn puts the wrong data in state.route as they all resolve to the last known route appended to the callback.

The solution proposed herein simply clones the callback cleanly and thus the trie code doesn't need to be modified. The alternative is to modify trie which is a bit more complex. This is the simplest solution i can think of. Related to #67 

@yoshuawuyts @tornqvist 