### PR TITLE
use nanoassert in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,12 @@
     "browser"
   ],
   "license": "MIT",
-  "dependencies": {},
+  "browser": {
+    "assert": "nanoassert"
+  },
+  "dependencies": {
+    "nanoassert": "^1.1.0"
+  },
   "devDependencies": {
     "istanbul": "^0.4.5",
     "mocha": "^3.1.2",


### PR DESCRIPTION
not sure why it didn't? makes a pretty big difference in choo's bundle size (if you're not using unassertify)